### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@autocomplete/material-ui": "^0.0.17",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "*",
+    "@material-ui/lab": "4.0.0-alpha.58",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
Build failed following autocomplete implementation due to error:
`Couldn't find any versions for "@material-ui/lab" that matches "*"`
Added version number to attempt fix